### PR TITLE
Fix directory validation for file location

### DIFF
--- a/Capsule/tk_utils/record.py
+++ b/Capsule/tk_utils/record.py
@@ -4,6 +4,7 @@
 
 import bpy
 
+import os.path
 from mathutils import Vector
 from . import search as search_utils
 from . import select as select_utils
@@ -598,7 +599,7 @@ def CheckCapsuleErrors(context, target_objects = None, target_collections = None
             return statement
         
         # TODO: Ensure this would properly validate a directory
-        if defaultFilePath[-1] != '\\':
+        if not os.path.isdir(defaultFilePath):
             statement = "The File Location '" + cap_file.location_presets[enumIndex].name + "' points to a file rather than a directory.  Please ensure it points to a folder."
             return statement
 


### PR DESCRIPTION
Hi!
I've tried to use Capsule on Linux and got an error during export. It falsely complained that file location points to a file instead of a directory. Turns out the check was working only for Windows. Here is how I fixed it.
Thanks for the plugin!